### PR TITLE
Fix nodecraft being half under the navbar

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,1 +1,1 @@
-body{background:#ededed}header{border-bottom:1px solid #cecece}header h1 small:before{content:"|";margin:0 .5em;font-size:1.6em}.push,footer{height:100px}footer{background:#ccc}
+body{background:#ededed}header{border-bottom:1px solid #cecece}header h1 small:before{content:"|";margin:0 .5em;font-size:1.6em}.push,footer{height:100px;background:#ccc}.nodecraft-header{height:75px;display:block}

--- a/index.php
+++ b/index.php
@@ -50,7 +50,7 @@
             </div>
             -->
             <header class="vertical-space">
-			    <a href="https://nodecraft.com/r/mmd"><img src="https://nodecraft.com/assets/images/logo-dark.png" widht="300" height="75" alt="Nodecraft Banner" align="right"></a>
+			    <a href="https://nodecraft.com/r/mmd" class="nodecraft-header"><img src="https://nodecraft.com/assets/images/logo-dark.png" width="300" height="75" alt="Nodecraft Banner" align="right"></a>
                 <br>
                 <nav class="ink-navigation">
                     <ul class="menu horizontal black">

--- a/members/index.php
+++ b/members/index.php
@@ -50,7 +50,7 @@
             </div>
             -->
             <header class="vertical-space">
-			    <a href="https://nodecraft.com/r/mmd"><img src="https://nodecraft.com/assets/images/logo-dark.png" widht="300" height="75" alt="Nodecraft Banner" align="right"></a>
+			    <a href="https://nodecraft.com/r/mmd" class="nodecraft-header"><img src="https://nodecraft.com/assets/images/logo-dark.png" width="300" height="75" alt="Nodecraft Banner" align="right"></a>
                 <br>
                 <nav class="ink-navigation">
                     <ul class="menu horizontal black">

--- a/projects/index.php
+++ b/projects/index.php
@@ -50,7 +50,7 @@
             </div>
             -->
             <header class="vertical-space">
-			    <a href="https://nodecraft.com/r/mmd"><img src="https://nodecraft.com/assets/images/logo-dark.png" widht="300" height="75" alt="Nodecraft Banner" align="right"></a>
+			    <a href="https://nodecraft.com/r/mmd" class="nodecraft-header"><img src="https://nodecraft.com/assets/images/logo-dark.png" width="300" height="75" alt="Nodecraft Banner" align="right"></a>
                 <br>
                 <nav class="ink-navigation">
                     <ul class="menu horizontal black">

--- a/projects/mods/index.php
+++ b/projects/mods/index.php
@@ -50,7 +50,7 @@
             </div>
             -->
             <header class="vertical-space">
-			    <a href="https://nodecraft.com/r/mmd"><img src="https://nodecraft.com/assets/images/logo-dark.png" widht="300" height="75" alt="Nodecraft Banner" align="right"></a>
+			    <a href="https://nodecraft.com/r/mmd" class="nodecraft-header"><img src="https://nodecraft.com/assets/images/logo-dark.png" width="300" height="75" alt="Nodecraft Banner" align="right"></a>
                 <br>
                 <nav class="ink-navigation">
                     <ul class="menu horizontal black">


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/10366817/94998855-02289200-0583-11eb-844f-f16a331bfada.png)
After:
![image](https://user-images.githubusercontent.com/10366817/94998866-0fde1780-0583-11eb-95a1-2a84966d220d.png)
