### PR TITLE
Update Code of Conduct with new section and other fixes

### DIFF
--- a/docs/CoC.md
+++ b/docs/CoC.md
@@ -1,20 +1,31 @@
 # Code Of Conduct
 
 ## Staff Roles & Expectations 
-- **Admins** - Admins are the ones making all of the top level decisions. If you have any questions, or want to arrange a partnership with MMD you should talk to them. Admins are expected to deal with public relations, and also make sure everyone is in line. That said they are not the dictators of MMD.
+- **Admins** - Admins are the ones making all of the top-level decisions. If you have any questions or want to arrange a partnership with MMD, you should talk to them. Admins are expected to deal with public relations, and also make sure everyone is in line. That said, they are not the dictators of MMD.
 - **Moderators** - Moderators help keep an eye on things. They are responsible for giving people the proper roles they need, and making sure everything runs smoothly. They are also responsible for answering questions about MMD, and making sure people are talking in the right place.
-- **Staff** - This role is for anyone who is considered part of the MMD staff. They will have a similar permission level to moderators, however they also maintain some other major project related to MMD, such as an official MMD server. While they can handle moderator stuff as well, that is not their primary purpose.
-- **Public Server Admins** - Public Server Admins are responsible for the Public Minecraft server which MMD hosts, the channel for this server is `#mmd-public-mc-server`.
+- **Staff** - This role is for anyone who is considered part of the MMD staff. They will have a similar permission level to moderators, however they also maintain some other major project related to MMD, such as an official MMD server. While they can handle moderator duties as well, that is not their primary purpose.
+- **Public Server Admin** - Public Server Admins are responsible for the public Minecraft server which MMD hosts. The channel for this server is `#public-minecraft-server`.
 
 ## Role Requirements
-The MMD server has many roles which are meant for members of the general community. These roles are usually given out by moderators when certain conditions are met. To request one of the roles below you must familiarize yourself with the requirements and, unless otherwise noted, contact a moderator (@Moderators) in the `#role-requests channel`.
+The MMD server has many roles which are meant for members of the general community. These roles are usually given out by moderators when certain conditions are met. To request one of the roles below you must familiarize yourself with the requirements and, unless otherwise noted, contact a moderator (@Moderators) in the `#role-requests` channel.
 
 - **Modder** - This role is for anyone who has made a mod or plugin for Minecraft. It is expected that anyone requesting this role has some level of experience with programming, and has a mod or plugin already published. To get this role you must provide a link to a mod/plugin you have authored. There are no size/download count requirements, however you will be required to provide some verification in form of screenshot or any other form the moderator sees fitting. (Editing the description of the mod on CurseForge with a message for the staff is preferred but other options are available)  
 - **Streamer/YouTuber** - This role is for anyone who has a YouTube or livestream channel. There are no size requirements, however some level of continuous activity is expected. To get this role you must provide a link to your channel and have Twitch or YouTube linked to your Discord account. If you have a big channel, you may be required to provide some additional verification. 
-- **Artist** - This role is for anyone who makes artwork. To get this role you must contact a moderator and provide a link to your portfolio. While there is no quality control for this role, you must have some history in making artwork. Verification may be required.
-- **Community rep** - This role is for members that we consider the best representatives of what we like to see in members of the community.
-- **Modpack Maker** - This role is for Modpack developers. There are no size/download count requirements, however you will be required to provide some verification in form of screenshot or any other form the moderator sees fitting. (Editing the description of the mod on CurseForge with a message for the staff is prefered but other options are avalable)
-- **MMD Public Server Players** - This role is for anyone who plays on MMD's public server. Should you want to be pinged with information about server and updates to the modpack please mention`@MMD Public Server Admins` and request the role be added to your account.  
+- **Artist/Modeler** - This role is for anyone who makes artwork. To get this role you must contact a moderator and provide a link to your portfolio. While there is no quality control for this role, you must have some history in making artwork. Verification may be required.
+- **Community Rep** - This role is for members that we consider the best representatives of what we like to see in members of the community.
+- **Modpack Maker** - This role is for Modpack developers. There are no size/download count requirements, however you will be required to provide some verification in form of screenshot or any other form the moderator sees fitting. (Editing the description of the mod on CurseForge with a message for the staff is preferred but other options are available)
+- **Translator** - This role is for anyone who translates mods to other languages. 
+- **Public Server Player** - This role is for anyone who plays on MMD's public server. Should you want to be pinged with information about server and updates to the modpack, please mention `@Public Server Admin` and request the role be added to your account.  
+
+### Other Roles
+These roles are given at the discretion of the MMD staff when certain conditions are met. These roles should not be requested in `#role-requests`.
+
+- **Bot** - This role is for Discord bots that operate on the server, under the guidance of the maintainers.
+- **Bot Maintainer** - This role is for the people that maintain the Discord bots on the server.
+- **Retired Staff** - This role is for staff who retire from their staff position and powers.
+- **SpookyJam 2019** - This role is for anyone who submitted an entry for SpookyJam 2019. 
+- **WinterJam 2019** - This role is for anyone who submitted an entry for WinterJam 2019.
+- **Nitro Booster** - This role is automatically granted to anyone who boosts the server with Discord Nitro.
 
 ## Warnings & Bans
 The MMD server uses an infraction based system for handling warnings and bans. Moderators and admins can issue infractions to members. Each infraction has an associated point value, the higher the points the more serious the infraction is. The types of infractions available are split into major and minor categories. 
@@ -23,25 +34,25 @@ The MMD server uses an infraction based system for handling warnings and bans. M
 - **EULA** - Given out when a member violates the [Minecraft EULA](https://account.mojang.com/terms), or promotes content that does. This includes sharing or authoring websites, servers, plugins and mods which violate the EULA. 
 - **Illegal Content** - Given out when someone posts content which is illegal, or promotes illegal activity. As MMD servers are located in the United States, the laws of that country will be used as the basis. This includes copyright laws and computer misuse laws. 
 - **Obscene Content** - Given out when someone posts content which is obscene. This includes sexually explicit content, and content which contains intense violence.
-- **Unpermitted Bot** - Given out to bots which have not been cleared to join the server. This includes spam bots, self bots and general discord bots. This infraction will cause an automatic perm ban. 
-- **Other** - This infraction can be given out for misc reasons. Moderators will be required to provide reasoning and evidence for this infraction, which will then be public for all members of staff. There is 0 tolerance for misuse of this infraction. 
+- **Unpermitted Bot** - Given out to bots which have not been cleared to join the server. This includes spam bots, self bots and general discord bots. This infraction will cause an automatic permanent ban. 
+- **Other** - This infraction can be given out for miscellaneous reasons. Moderators will be required to provide reasoning and evidence for this infraction, which will then be public for all members of staff. There is 0 tolerance for misuse of this infraction. 
 
 Note that in cases where illegal activity is involved, the details for the poster should be [reported to Discord Trust and Safety directly](https://support.discordapp.com/hc/en-us/articles/360000291932-How-to-Properly-Report-Issues-to-Trust-Safety). 
 
 ### Minor - 1 point
 - **Flame/Provoke** - Given out to members who make posts with the intention of provoking a negative reaction from other members.
-- **Advertise** - Given out to members who try to take advantage of MMD to promote their own content. Exceptions are commonly given to this rule, for things like mod authors sharing their mods, or MMD partners. Please see the advertising policy for more info. 
+- **Advertise** - Given out to members who try to take advantage of MMD to promote their own content. Exceptions are commonly made to this rule, such as mod authors sharing their mods, or MMD partners. Please see the advertising policy for more info. 
 - **Bot Abuse** - Given out to those who take advantage of a bot for malicious purposes. This does not include those who are testing the bot in the proper testing channel. 
 - **Spam** - Given to those who send messages with no value. Things like spamming random characters.
 - **Backseat/Mini Modding** - Given to members who act like a moderator or administrator without having the authority to do so. This does not cover situations where members are being helpful, such as directing others to the appropriate room for discussion. 
-- **Malicious Conduct** - Given to members who behave in a manner which can cause distress, harm or inconvenience to the other members. This includes discrimination, bullying, hate speech, using multiple accounts to evade a ban/warning, doxxing, pinging without a proper cause and so on.
+- **Malicious Conduct** - Given to members who behave in a manner which can cause distress, harm or inconvenience to the other members. This includes discrimination, bullying, hate speech, using multiple accounts to evade a ban/warning, doxxing (publicly posting personal/private information about another person), pinging without a proper cause and so on.
 - **Unsuitable Name** - Given to members who have a name which is not suitable. These names include those which are insensitive, malicious or deceiving. This **should** be used for staff impersonation as well. 
-- **Other** - This infraction can be given out for misc reasons. Moderators will be required to provide reasoning and evidence for this infraction, which will then be public for all members of staff. There is 0 tolerance for misuse of this infraction. 
+- **Other** - This infraction can be given out for miscellaneous reasons. Moderators will be required to provide reasoning and evidence for this infraction, which will then be public for all members of staff. There is 0 tolerance for misuse of this infraction. 
 
 ### Infraction Policy
 If a moderator feels that a member is deserving of an infraction, they can issue one of the predefined infractions. Infractions are created through a bot, which will require the staff member to include reasoning and evidence. Once the infraction has been completed, it will be entered into our system, and the member being given an infraction will be sent a direct message through the bot informing them of the infraction. Points will eventually expire, however they will remain in the database. 
 
-If a member has 3 infraction points, they will be temporarily suspended from MMD. During the suspension period the admins will review the member's history and determine whether or not a ban is needed. Every further infraction will require invoke another admin review. 
+If a member has 3 infraction points, they will be temporarily suspended from MMD. During the suspension period, the admins will review the member's history and determine whether or not a ban is needed. Every further infraction will require invoke another admin review. 
 
 There is zero tolerance for misuse of the infraction system. All infractions must include evidence of some sort. In cases where said evidence would be illegal to reproduce, other forms of verification such as 3rd hand testimonials are acceptable. 
 
@@ -67,32 +78,36 @@ NOTE: Webhooks do not count towards channels being active, only user activity is
 
 ## Channels
 - **#rules** - This is where we keep all of our rules, please be sure to read it to save us time and yourself getting into trouble.
-- **#readme** - This channel has information about MMD, how to apply for roles and our invite link. Please make sure you read through it.
+- **#readme** - This channel has information about MMD, how to apply for roles, and our invite link. Please make sure you read through it.
 - **#announcements** - Used for announcements related to MMD, Minecraft, the community and partners, along with important world events. 
 - **#community-announcements** - Used by the community to share announcements for their own projects. We request that you link to the project overview page rather than a direct download. Responses and discussion about announcements should be done in a separate channel, however, adding reaction emoji is fine.
-### GENERAL
-- **#general** - The main discussion channel on the discord. Conversations don't have to be about Minecraft however extremely off topic discussions should move to #stopthatitsverysilly
-- **#mmd-public-server** - The chat for the public Minecraft server. Also contains a relay between server chat and discord.
+### GENERAL TALK
+- **#general** - The main discussion channel on the discord. Conversations don't have to be about Minecraft, however extremely off topic discussions should move to #stopthatitsverysilly
+- **#public-minecraft-server** - The chat for the public Minecraft server. Also contains a relay between server chat and discord.
 - **#showcase** - Used to show new content made by the community, not for posting mod announcements.
 - **#modpacks** - The place used to ask questions about modpack development, and discussion relating to modpacks.
 - **#art** - Used to discuss art you've made, or wanted to share. Keep the chat SFW!
 - **#other-games** - A place to talk about games, play games or share news about games with others.
-- **#stopthatitsverysilly** - Off topic discussion, memes, silly conversations. No hateful, inflamatory, NSFW or anime allowed.
-### DEVELOPMENT
+- **#stopthatitsverysilly** - Off topic discussion, memes, silly conversations. No hateful, inflammatory, NSFW or anime allowed.
+### MINECRAFT-DEVELOPMENT
 - **mc-dev-1-16** - Development of mods for 1.16 versions.
 - **mc-dev-1-15** - Development of mods for 1.15 versions.
 - **mc-dev-1-12** - Development of mods for 1.12 versions.
 - **mc-dev-other** - Development of mods for any other versions of Minecraft that do not have a dedicated channel.
 - **mc-design** - Get tips and ideas for concepts you are working on or just talk about content you want to make and see if the community have feedback.
 ### NON-MC-DEVELOPMENT
-- **#other-development** - The place to ask questions or generally discuss non minecraft related coding.
+- **#other-development** - The place to ask questions or generally discuss non-minecraft related coding.
 - **#other-design** - The place to get design ideas and feedback for other projects you might be working on.
 ### COMMISSIONS/IDEAS
 - **free-mod-ideas** - The place to post mod ideas or concepts that you don't have time or skill to create, these are usually for other people to take and create.
 - **idea-discussion** - We talk about these free mod ideas here, give feedback and suggestions or just let the person know that you are taking the ideas to make them work.
 - **#requests** - The place for people to post requests for art, mods and other things. Responses and discussion about requests should be done in the **#requests-discussion** channel, however, adding reaction emoji is fine.
-- **#requests-discussion** - The place to talk about requests posted in #requests
+- **#requests-discussion** - The place to talk about requests posted in #requests.
+### MMD-SUGGESTIONS
+- **#fulfilled-suggestions** - Information about previous suggestions which have been implemented by MMD.
+- **#suggestion-box** - The place for making suggestions to improve MMD. Responses and discussion about suggestions should be done in the **#suggestions-discussion** channel, however, adding reaction emoji is fine.
+- **#suggestions-discussion** - The place to talk about posted suggestions in #suggestion-box.
 ### MISC
 - **#bot-stuff** - This channel is the main place to use any of MMD's bots.
-- **#role-requests** - Request a modder, artist, translator, modpack maker or streamer here. (See Role Requirements for more information)
+- **#role-requests** - Request the modder, artist, translator, modpack maker or streamer roles here. (See Role Requirements for more information)
 - **#channel-management** - Request a channel for your mod/s here. (You must have the Modder role already to request a channel)

--- a/docs/CoC.md
+++ b/docs/CoC.md
@@ -23,6 +23,7 @@ These roles are given at the discretion of the MMD staff when certain conditions
 - **Bot** - This role is for Discord bots that operate on the server, under the guidance of the maintainers.
 - **Bot Maintainer** - This role is for the people that maintain the Discord bots on the server.
 - **Retired Staff** - This role is for staff who retire from their staff position and powers.
+- **Event Team** - This role is for staff that manage and organize the currently running event, such as SpookyJam.
 - **SpookyJam 2020** - This role is for anyone who submitted an entry for SpookyJam 2020.
 - **SpookyJam 2019** - This role is for anyone who submitted an entry for SpookyJam 2019. 
 - **WinterJam 2019** - This role is for anyone who submitted an entry for WinterJam 2019.

--- a/docs/CoC.md
+++ b/docs/CoC.md
@@ -23,6 +23,7 @@ These roles are given at the discretion of the MMD staff when certain conditions
 - **Bot** - This role is for Discord bots that operate on the server, under the guidance of the maintainers.
 - **Bot Maintainer** - This role is for the people that maintain the Discord bots on the server.
 - **Retired Staff** - This role is for staff who retire from their staff position and powers.
+- **SpookyJam 2020** - This role is for anyone who submitted an entry for SpookyJam 2020.
 - **SpookyJam 2019** - This role is for anyone who submitted an entry for SpookyJam 2019. 
 - **WinterJam 2019** - This role is for anyone who submitted an entry for WinterJam 2019.
 - **Nitro Booster** - This role is automatically granted to anyone who boosts the server with Discord Nitro.


### PR DESCRIPTION
Updates `CoC.md` with a variety of different additions and changes:

* Fixed references to the public minecraft server channel `#public-minecraft-server`.
* Added **Translator** role to the list of community-given roles.
* Fixed references to **Artist/Modeler**, **Community Rep** and **Public Server Player** to be accurate to the real roles in the server.
  * [Darkhax said][darkhax_translator] that the **Translator** role exists and is requested in `#role-requests`, however there is no formalized process or requirements in place. To that end, the PR only briefly touches on the role, and should be updated once the process/requirements are finalized.
* Added new section on roles that aren't requested in `#role-requests` but are given on certain conditions and the staff's discretion.
* Added small note next to the word 'doxxing' to explain the meaning of the term.
* Updated section on channels to reflect the current state of the channels and categories on the server.
  * Includes a new subsection on the suggestions category and channels.
* Expanded some abbreviated words, fixed spelling mistakes, added commas and reworded some phrases to improve readability.

[darkhax_translator]: https://discord.com/channels/176780432371744769/176780432371744769/770916123490648084