### PR TITLE
Create new Code of Conduct

### DIFF
--- a/code-of-conduct.txt
+++ b/code-of-conduct.txt
@@ -32,7 +32,13 @@ Note that in cases where illegal activity is involved, the details for the poste
 
 - **Spam** - Don't send the same (or very similar) message multiple times, in the same channel or in different channels. This includes crossposting requests and spamming one-word messages. It's incredibly annoying, don't do it. 
 
----- Section: Staff Obligations ----
+---- Section: Roles ----
+
+## Staff Roles
+
+MMD has various roles for keeping track of the members of staff with various responsibilities.  
+If you want to bring something to the attention of a member in any one of these roles, please ping the whole role, rather than any individual member.  
+Please remember that people use offline mode, so it may appear that nobody in a role is online while potentially all of them are.  
 
 - **Admins** - Admins make all of the top-level decisions. If you have any concerns, you should talk to them. Admins deal with public relations, and ensure the community is healthy. That said, they are not dictators. There are always three admins, to ensure that there can never be a stalemate with important decisions. 
 
@@ -45,18 +51,18 @@ Note that in cases where illegal activity is involved, the details for the poste
 Footnote: All staff are volunteers and help out during their free time. Everyone; both staff and community members, are entitled to their own thoughts and beliefs. Sometimes those thoughts won't represent MMD as a whole.
 Remember, staff are humans too and should be treated as such. If you are found to be disrespecting staff, or staff are found disrespecting community members, another member of staff will deal with the issue appropriately.
 
----- Section: Role Requirements ----
+## Community Roles
 
-The MMD server has many roles for members of the community. 
+The MMD server has some roles for members of the community, that you can ask for.
 These roles are given out by moderators when a user goes through the request process. To request one of the roles below you must familiarize yourself with the requirements and, unless otherwise noted, contact a moderator (@Moderators) in the `role-and-channel-requests` channel.
 
-- **Mod Coder** - This role is for anyone who was involved in the programming of a mod or plugin for Minecraft. You must have a mod or plugin already published. You must prove that you have contributed to the mod - GitHub and CurseForge screenshots are acceptable. However, MCreator users will ***NOT*** be granted roles, due to our policies.
+- **Mod Coder** - This role is for anyone who was involved in the programming of a mod or plugin for Minecraft. 
 
-- **Artist/Modeler** - This role is for anyone who makes Minecraft models, textures and related artwork. You must prove that you made the model or texture by adding the phrase "MMD" to it, but this can be deleted after verification. Note that this is explicitly for MINECRAFT artwork, you cannot apply with random art you have made.
+- **Artist/Modeler** - This role is for anyone who makes Minecraft models, textures and related artwork. 
 
 - **Community Rep** - This role is for members that we consider the best representatives of what the community has to offer.
 
-- **Modpack Maker** - This role is for Modpack developers. There are no size/download count requirements, however you will be required to verify with a CurseForge screenshot.
+- **Modpack Maker** - This role is for Modpack developers. 
 
 - **Translator** - This role is for anyone who translates mods to other languages. 
 
@@ -78,18 +84,36 @@ These roles are given at the discretion of the MMD staff when certain conditions
 
 - **WinterJam** - This role is for anyone who submitted an entry for past WinterJam events. This is a legacy role and can no longer be given out.
 
---- Section: Community Channels ----
+--- Section: Requests ----
 
-MMD allows members to request channels for their modding projects/teams. 
-Channel requests are mainly reserved for mod authors and those with projects that need a place to start out and grow. Community Channels belong in their own category, and are sorted alphabetically by the bot.
+## Roles
+MMD members can request a specific set of roles. See (#roles) for an explanation of what they are.
+However, the requirements for approval for the various rules are different, and shall be explained here:
 
-PLEASE NOTE: Channel owners are allowed to manage their own permissions, *however*, certain permissions are globally disabled on MMD and should *not* be re-enabled for *anyone*, including yourself, on user channels. 
-Permissions such as "Mention Everyone" are completely forbidden in every channel.
+- **Mod Coder** -  You must have a mod or plugin already published, via Modrinth or CurseForge. You must prove that you have contributed to the mod - GitHub is acceptable, as well as screenshots of CurseForge/Modrinth project management. However, MCreator users will ***NOT*** be granted roles, due to our policies.
 
-In addition, changing the permissions for bots and staff members is prohibited, as is moving your channel to another category/above or below it's set place. Violations of these rules may lead to having your channel removed and an infraction added to the channel owner or owners.
+- **Artist / Modeller** -  You must prove that you made the model or texture by adding the phrase "MMD" to it, but this can be deleted after verification. Note that this is explicitly for MINECRAFT artwork, you cannot apply with random art you have made.
+Alternatively, word-of-mouth from somebody else involved in the project is acceptable if, for example, you cannot currently edit the model/texture.
 
-If a user channel is inactive for 60+ days, a member of staff or the bot will send a message asking the channel owner to contact moderators. If no contact is made within 2 weeks (14 days), the channel will be archived.
+- **Modpack Maker / Translator** - There are no hard requirements for these roles, however some meaningful verification is required (eg. Github, CurseForge, other team members.)
 
-Archived channels are stored for up to 1 year and may be revived by staff upon request, only previous owner of the channel may request a channel revival and the user ID's must match to do so.
+For context on what constitutes as "CurseForge" verification, please note two things about the following screenshot:
+- The management page is open, and settings about the mod can be visibly modified.
+- The user page is open (the top right corner), and the user's profile picture and name can be seen.
 
-Note: Webhooks do not count towards channels being active, only user activity is counted.
+All verification for mods and modpacks must include a screenshot with both of these features open.
+<img src="/mmd/img/curseforge.png" id="curseforgeimage" style="width:100%; "></i>
+
+## Channels
+MMD allows members to request channels for their modding projects or teams.
+The modder will gain a portion of the community they can own for themselves; you may add webhooks, manage and pin messages, and do whatever you would otherwise like to do within your channel.
+
+Members that own channels are given free reign on the setup, but you must obey two specific rules:
+- Do not change permissions for Staff or Bot roles.
+- Do not grant ANYBODY the "Mention Everyone" permission.
+
+### Channel Archival
+Channels are expected to be moderately active; if there is no user activity (that means, webhooks from other servers don't count) in 60 days, we will follow up.
+If there is still no response, you will be presumed to be inactive, and the channel will be archived into a read-only state.	
+
+Archival lasts for up to 1 year. You may request that a channel be unarchived, but only if you are the one that originally requested it.

--- a/code-of-conduct.txt
+++ b/code-of-conduct.txt
@@ -1,0 +1,95 @@
+---- Section: Community Expectations ----
+
+## Warnings & Bans
+The MMD server uses a transparent infraction-based system for handling moderation. Moderators and admins can issue infractions to members. 
+Each infraction has an associated severity; the higher the severity, the more serious the infraction is. 
+
+Every applied infraction; every warning, mute and ban, are public and viewable.
+
+The basic expectations of every member of the community are as follows:
+
+### Severity: Major
+
+- **Infringing Minecraft's EULA and/or Commercial Usage Guidelines** - Do not violate the [Minecraft EULA](https://account.mojang.com/terms), or promote content that does. This includes sharing or authoring websites, servers, plugins and mods which violate the EULA. 
+
+- **Illegal Content** - Do not post content which is illegal, or promotes illegal activity. MMD is located in the United States, so the laws of the US are applied. This especially includes copyright and computer misuse laws. 
+
+- **Obscene Content** - Do not post content which is obscene. This includes (but is not limited to) sexually explicit content, and content which contains intense violence.
+
+Note that in cases where illegal activity is involved, the details for the poster should be [reported to Discord Trust and Safety directly](https://support.discordapp.com/hc/en-us/articles/360000291932-How-to-Properly-Report-Issues-to-Trust-Safety). 
+
+### Severity: Minor
+
+- **Provoking / Trolling / Drama Farming** - Dont post or message with the intention of provoking a negative reaction from other members, or make statements that are fully opinion based, but which tend to cause drama. This includes religious and sexist messages.
+
+- **Hate** - Don't share hate messages. This includes discrimination, bullying, general "hate speech", and doxxing (publicly posting personal/private information about another person)
+
+- **Advertising** - Don't advertise your own content or Discord servers without permission. Advertising includes posting images in random channels, or unwarranted invites to Discord servers. Members with the Regular role have permission to (and are encouraged to) advertise with the proper methods. However, if a user asks for an invite to a server, you are more than welcome to share them.
+
+(Note: Discord invite clarification for the current rule of "seek permission or be asked for an invite" needed)
+
+- **Bot Abuse** - Don't use any bot for malicious purposes. This does not apply to members with the Bot Maintainer role testing bots they are actively working on, but ONLY for testing purposes. If/when a member of staff or a Bot Maintainer asks you to stop or not use a feature, make sure you follow that request as if a moderator was asking you to do so.
+
+- **Spam** - Don't send the same (or very similar) message multiple times, in the same channel or in different channels. This includes crossposting requests and spamming one-word messages. It's incredibly annoying, don't do it. 
+
+---- Section: Staff Obligations ----
+
+- **Admins** - Admins make all of the top-level decisions. If you have any concerns, you should talk to them. Admins deal with public relations, and ensure the community is healthy. That said, they are not dictators. There are always three admins, to ensure that there can never be a stalemate with important decisions. 
+
+- **Moderators** - Moderators monitor the public channels. They are responsible for allocating roles, removing rule-breakers, and making sure everything runs smoothly. They are also responsible for answering general questions about MMD, and making sure people are talking in the right channels.
+
+-- **Junior Moderators** - Junior Moderators are in the process of becoming full moderators. They don't have the authority that full moderators do, but they have the authority they need to do their job. Be kind to them, make sure to keep them on their toes (within reason) and put your trust in them.
+
+- **Staff** - This role is for every member of MMD's different staff teams. The role has no inherent permissions, their duties are determined by having any of the higher roles. Do not ping the Staff role for moderation duties! 
+
+Footnote: All staff are volunteers and help out during their free time. Everyone; both staff and community members, are entitled to their own thoughts and beliefs. Sometimes those thoughts won't represent MMD as a whole.
+Remember, staff are humans too and should be treated as such. If you are found to be disrespecting staff, or staff are found disrespecting community members, another member of staff will deal with the issue appropriately.
+
+---- Section: Role Requirements ----
+
+The MMD server has many roles for members of the community. 
+These roles are given out by moderators when a user goes through the request process. To request one of the roles below you must familiarize yourself with the requirements and, unless otherwise noted, contact a moderator (@Moderators) in the `role-and-channel-requests` channel.
+
+- **Mod Coder** - This role is for anyone who was involved in the programming of a mod or plugin for Minecraft. You must have a mod or plugin already published. You must prove that you have contributed to the mod - GitHub and CurseForge screenshots are acceptable. However, MCreator users will ***NOT*** be granted roles, due to our policies.
+
+- **Artist/Modeler** - This role is for anyone who makes Minecraft models, textures and related artwork. You must prove that you made the model or texture by adding the phrase "MMD" to it, but this can be deleted after verification. Note that this is explicitly for MINECRAFT artwork, you cannot apply with random art you have made.
+
+- **Community Rep** - This role is for members that we consider the best representatives of what the community has to offer.
+
+- **Modpack Maker** - This role is for Modpack developers. There are no size/download count requirements, however you will be required to verify with a CurseForge screenshot.
+
+- **Translator** - This role is for anyone who translates mods to other languages. 
+
+### Other Roles
+
+These roles are given at the discretion of the MMD staff when certain conditions are met. These roles can not be requested by community members.
+
+- **Bot** - This role is for Discord bots that operate on the server, under the guidance of the maintainers.
+
+- **Bot Maintainer** - This role is for the people that maintain the Discord bots on the server.
+
+- **Retired Staff** - This role is for staff who retire from their staff position and powers but are deserving of recognition for their effors and support during their time at MMD.
+
+- **Event Team** - This role is for staff that manage our hosted modding events within MMD's server.
+
+- **Contestant** - This role is for everyone who has submitted mods to any of our Modding Fest events.
+
+- **SpookyJam** - This role is for anyone who submitted an entry for past SpookyJam events. This is a legacy role and can no longer be given out.
+
+- **WinterJam** - This role is for anyone who submitted an entry for past WinterJam events. This is a legacy role and can no longer be given out.
+
+--- Section: Community Channels ----
+
+MMD allows members to request channels for their modding projects/teams. 
+Channel requests are mainly reserved for mod authors and those with projects that need a place to start out and grow. Community Channels belong in their own category, and are sorted alphabetically by the bot.
+
+PLEASE NOTE: Channel owners are allowed to manage their own permissions, *however*, certain permissions are globally disabled on MMD and should *not* be re-enabled for *anyone*, including yourself, on user channels. 
+Permissions such as "Mention Everyone" are completely forbidden in every channel.
+
+In addition, changing the permissions for bots and staff members is prohibited, as is moving your channel to another category/above or below it's set place. Violations of these rules may lead to having your channel removed and an infraction added to the channel owner or owners.
+
+If a user channel is inactive for 60+ days, a member of staff or the bot will send a message asking the channel owner to contact moderators. If no contact is made within 2 weeks (14 days), the channel will be archived.
+
+Archived channels are stored for up to 1 year and may be revived by staff upon request, only previous owner of the channel may request a channel revival and the user ID's must match to do so.
+
+Note: Webhooks do not count towards channels being active, only user activity is counted.


### PR DESCRIPTION
MMD is continually evolving and changing.

The old wall-of-text style of the CoC was putting members off reading it, when it is in actuality a very important document.

To this end, me and @KiriCattus have gone through and split it up into distinct logical sections, so that it can be laid out better on a web page.

The Code of Conduct is NOT intended for consumption via markdown, hence the weird formatting here.

Additionally, a few new policies and features are mentioned here that have not yet been implemented on MMD itself - that is the main reason this is a PR.
